### PR TITLE
fix: cookie persistence and auth success detection

### DIFF
--- a/scripts/auth-flow.js
+++ b/scripts/auth-flow.js
@@ -83,11 +83,22 @@ async function runAuthFlow(sessionName, url, options = {}) {
       if (options.successSelector) {
         const el = await page.$(options.successSelector);
         if (el) {
-          const currentUrl = page.url();
-          await closeBrowser(sessionName, context);
-          sessionStore.updateSession(sessionName, { status: 'authenticated' });
-          sessionStore.unlockSession(sessionName);
-          return { ok: true, session: sessionName, url: currentUrl };
+          // For attribute selectors, verify the attribute has a non-empty value
+          const isValid = await el.evaluate(node => {
+            // Check common auth indicators - meta tags with content, visible elements
+            if (node.tagName === 'META' && node.hasAttribute('content')) {
+              return node.getAttribute('content').trim().length > 0;
+            }
+            return true;
+          }).catch(() => false);
+
+          if (isValid) {
+            const currentUrl = page.url();
+            await closeBrowser(sessionName, context);
+            sessionStore.updateSession(sessionName, { status: 'authenticated' });
+            sessionStore.unlockSession(sessionName);
+            return { ok: true, session: sessionName, url: currentUrl };
+          }
         }
       }
 

--- a/scripts/browser-launcher.js
+++ b/scripts/browser-launcher.js
@@ -88,12 +88,6 @@ async function launchBrowser(sessionName, options = {}) {
     }
   }
 
-  // Restore storage state if available
-  const storageState = sessionStore.loadStorageState(sessionName);
-  if (storageState) {
-    launchOptions.storageState = storageState;
-  }
-
   // Try system Chrome first, fall back to Playwright bundled Chromium
   let context;
   try {
@@ -102,6 +96,12 @@ async function launchBrowser(sessionName, options = {}) {
   } catch {
     delete launchOptions.channel;
     context = await chromium.launchPersistentContext(profileDir, launchOptions);
+  }
+
+  // Restore cookies after launch (storageState option is ignored for persistent contexts)
+  const storageState = sessionStore.loadStorageState(sessionName);
+  if (storageState && storageState.cookies && storageState.cookies.length > 0) {
+    await context.addCookies(storageState.cookies);
   }
 
   // Anti-bot init script on all pages


### PR DESCRIPTION
## Summary

- Fixed cookie restoration: `storageState` option is ignored by `launchPersistentContext`, so cookies are now injected via `context.addCookies()` after launch
- Fixed auth success detection: `page.$()` only checks element existence, not attribute values. Added `evaluate()` check to verify `meta[content]` has a non-empty value before declaring auth success

## Test plan

- [ ] Run auth flow and verify browser stays open until actual login completes
- [ ] Verify cookies persist across headless sessions after auth