### PR TITLE
feat: VNC fallback for auth on remote/headless servers

### DIFF
--- a/scripts/auth-flow.js
+++ b/scripts/auth-flow.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { launchBrowser, closeBrowser } = require('./browser-launcher');
+const { launchBrowser, closeBrowser, canLaunchHeaded } = require('./browser-launcher');
 const sessionStore = require('./session-store');
+const { runVncAuth, isVncAvailable } = require('./vnc-auth');
 
 const CAPTCHA_SELECTORS = [
   'iframe[src*="arkose"]',
@@ -50,6 +51,25 @@ async function detectCaptcha(page) {
  * @returns {{ ok, session, error, captchaDetected }}
  */
 async function runAuthFlow(sessionName, url, options = {}) {
+  // Force VNC mode
+  if (options.vnc) {
+    return runVncAuth(sessionName, url, options);
+  }
+
+  // Auto-detect: try headed, fallback to VNC
+  const headed = await canLaunchHeaded();
+  if (!headed) {
+    if (isVncAvailable()) {
+      return runVncAuth(sessionName, url, options);
+    }
+    return {
+      ok: false,
+      session: sessionName,
+      error: 'no_display',
+      message: 'No display available for headed browser. Install Xvfb, x11vnc, and websockify for remote auth: sudo apt-get install xvfb x11vnc websockify novnc'
+    };
+  }
+
   const timeout = (options.timeout || 300) * 1000;
   const pollInterval = 2000;
 

--- a/scripts/browser-launcher.js
+++ b/scripts/browser-launcher.js
@@ -138,4 +138,34 @@ async function closeBrowser(sessionName, context) {
   return warning;
 }
 
-module.exports = { launchBrowser, closeBrowser, randomDelay, isWSL };
+/**
+ * Test whether a headed (non-headless) browser can launch on this system.
+ * Caches result after first check.
+ */
+let _headedResult = null;
+async function canLaunchHeaded() {
+  if (_headedResult !== null) return _headedResult;
+
+  // No DISPLAY at all - definitely can't launch headed
+  if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    _headedResult = false;
+    return false;
+  }
+
+  // Try a quick headed launch
+  const { chromium } = require('playwright');
+  try {
+    const ctx = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: ['--no-first-run', '--no-default-browser-check'],
+      timeout: 5000
+    });
+    await ctx.close();
+    _headedResult = true;
+  } catch {
+    _headedResult = false;
+  }
+  return _headedResult;
+}
+
+module.exports = { launchBrowser, closeBrowser, randomDelay, isWSL, canLaunchHeaded };

--- a/scripts/vnc-auth.js
+++ b/scripts/vnc-auth.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { spawn, execFileSync } = require('child_process');
+const { launchBrowser, closeBrowser } = require('./browser-launcher');
+const sessionStore = require('./session-store');
+const net = require('net');
+
+/**
+ * Find a free TCP port.
+ */
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+/**
+ * Check if a command exists on PATH.
+ */
+function commandExists(cmd) {
+  try {
+    execFileSync('which', [cmd], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if VNC auth is available (Xvfb + websockify + x11vnc).
+ */
+function isVncAvailable() {
+  return commandExists('Xvfb') && commandExists('websockify') && commandExists('x11vnc');
+}
+
+/**
+ * Find noVNC web directory.
+ */
+function findNoVncDir() {
+  const fs = require('fs');
+  const candidates = ['/usr/share/novnc', '/usr/share/noVNC', '/opt/novnc', '/opt/noVNC'];
+  for (const dir of candidates) {
+    if (fs.existsSync(dir)) return dir;
+  }
+  return null;
+}
+
+/**
+ * Get hostname for VNC URL. Prefer non-loopback IPv4.
+ */
+function getHostname() {
+  try {
+    const os = require('os');
+    const interfaces = os.networkInterfaces();
+    for (const name of Object.keys(interfaces)) {
+      for (const iface of interfaces[name]) {
+        if (iface.family === 'IPv4' && !iface.internal) return iface.address;
+      }
+    }
+  } catch { /* ignore */ }
+  return 'localhost';
+}
+
+/**
+ * Clean up all spawned processes and session state.
+ */
+async function cleanup(sessionName, context, procs) {
+  if (context) {
+    try { await closeBrowser(sessionName, context); } catch { /* ignore */ }
+  }
+  try { sessionStore.updateSession(sessionName, { status: 'authenticated' }); } catch { /* ignore */ }
+  try { sessionStore.unlockSession(sessionName); } catch { /* ignore */ }
+
+  for (const proc of procs) {
+    if (proc && proc.exitCode === null) {
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Run auth flow via Xvfb + x11vnc + noVNC.
+ *
+ * Launches Chrome inside a virtual framebuffer and exposes it via
+ * websockify + noVNC so the user can authenticate through their local browser.
+ */
+async function runVncAuth(sessionName, url, options = {}) {
+  const timeout = (options.timeout || 300) * 1000;
+  const pollInterval = 2000;
+  const displayNum = 99 + Math.floor(Math.random() * 100);
+  const display = `:${displayNum}`;
+  const rfbPort = 5900 + displayNum;
+
+  let xvfbProc = null;
+  let x11vncProc = null;
+  let websockifyProc = null;
+  let context = null;
+
+  try {
+    sessionStore.lockSession(sessionName);
+
+    // 1. Start Xvfb
+    xvfbProc = spawn('Xvfb', [display, '-screen', '0', '1280x800x24', '-ac'], {
+      stdio: 'ignore', detached: true
+    });
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    if (xvfbProc.exitCode !== null) throw new Error(`Xvfb failed to start on display ${display}`);
+
+    // 2. Start x11vnc
+    x11vncProc = spawn('x11vnc', [
+      '-display', display, '-nopw', '-forever', '-shared', '-rfbport', String(rfbPort)
+    ], { stdio: 'ignore', detached: true });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // 3. Start websockify + noVNC
+    const noVncDir = findNoVncDir();
+    const vncPort = options.port || await findFreePort();
+    const websockifyArgs = noVncDir
+      ? ['--web', noVncDir, String(vncPort), `localhost:${rfbPort}`]
+      : [String(vncPort), `localhost:${rfbPort}`];
+
+    websockifyProc = spawn('websockify', websockifyArgs, {
+      stdio: 'ignore', detached: true
+    });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // 4. Launch Chrome inside Xvfb
+    const origDisplay = process.env.DISPLAY;
+    process.env.DISPLAY = display;
+    const browser = await launchBrowser(sessionName, { headless: false });
+    context = browser.context;
+    const page = browser.page;
+    process.env.DISPLAY = origDisplay || '';
+
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    // 5. Build VNC URL and notify
+    const hostname = getHostname();
+    const isPrivateIp = /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(hostname);
+    const displayHost = isPrivateIp ? 'localhost' : hostname;
+    const vncUrl = noVncDir
+      ? `http://${displayHost}:${vncPort}/vnc.html?autoconnect=true`
+      : null;
+
+    const tunnelHint = isPrivateIp
+      ? `  If remote, forward first: ssh -L ${vncPort}:localhost:${vncPort} <server>`
+      : '';
+    const info = {
+      vncUrl, vncPort, display,
+      message: vncUrl
+        ? `Authenticate via browser: ${vncUrl}`
+        : `VNC server on port ${rfbPort}. Connect with a VNC client.`
+    };
+
+    process.stderr.write(`\n[web-ctl] ${info.message}\n${tunnelHint ? '[web-ctl] ' + tunnelHint + '\n' : ''}\n`);
+
+    // 6. Poll for auth success
+    const startTime = Date.now();
+    const procs = [websockifyProc, x11vncProc, xvfbProc];
+
+    while (Date.now() - startTime < timeout) {
+      if (options.successUrl) {
+        const currentUrl = page.url();
+        if (currentUrl.startsWith(options.successUrl)) {
+          await cleanup(sessionName, context, procs);
+          return { ok: true, session: sessionName, url: currentUrl, ...info };
+        }
+      }
+
+      if (options.successSelector) {
+        const el = await page.$(options.successSelector);
+        if (el) {
+          const isValid = await el.evaluate(node => {
+            if (node.tagName === 'META' && node.hasAttribute('content')) {
+              return node.getAttribute('content').trim().length > 0;
+            }
+            return true;
+          }).catch(() => false);
+          if (isValid) {
+            const currentUrl = page.url();
+            await cleanup(sessionName, context, procs);
+            return { ok: true, session: sessionName, url: currentUrl, ...info };
+          }
+        }
+      }
+
+      if (!options.successUrl && !options.successSelector) {
+        const currentUrl = page.url();
+        if (currentUrl !== url && !currentUrl.includes('login') && !currentUrl.includes('signin')) {
+          const cookies = await context.cookies('https://github.com');
+          const loggedIn = cookies.find(c => c.name === 'logged_in' && c.value === 'yes');
+          if (loggedIn || !currentUrl.includes('github.com')) {
+            await cleanup(sessionName, context, procs);
+            return { ok: true, session: sessionName, url: currentUrl, ...info };
+          }
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+    }
+
+    await cleanup(sessionName, context, procs);
+    return { ok: false, session: sessionName, error: 'auth_timeout', message: `VNC auth timed out after ${options.timeout || 300}s`, ...info };
+  } catch (err) {
+    await cleanup(sessionName, context, [websockifyProc, x11vncProc, xvfbProc]);
+    return { ok: false, session: sessionName, error: 'vnc_auth_error', message: err.message };
+  }
+}
+
+module.exports = { runVncAuth, isVncAvailable };

--- a/scripts/web-ctl.js
+++ b/scripts/web-ctl.js
@@ -120,7 +120,9 @@ async function sessionAuth(name, opts) {
   const result = await runAuthFlow(name, opts.url, {
     successUrl: opts.successUrl,
     successSelector: opts.successSelector,
-    timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined
+    timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+    vnc: !!opts.vnc,
+    port: opts.port ? parseInt(opts.port, 10) : undefined
   });
 
   output({ command: 'session auth', ...result });

--- a/skills/web-auth/SKILL.md
+++ b/skills/web-auth/SKILL.md
@@ -2,7 +2,7 @@
 name: web-auth
 description: "Authenticate to websites with human-in-the-loop browser handoff. Use when user needs to log into a website, complete 2FA, or solve CAPTCHAs for agent access."
 version: 1.0.0
-argument-hint: "[session-name] --url [login-url] [--success-url [url]] [--timeout [seconds]]"
+argument-hint: "[session-name] --url [login-url] [--success-url [url]] [--timeout [seconds]] [--vnc]"
 ---
 
 # Web Auth Skill
@@ -35,9 +35,18 @@ If the session already exists, skip this step.
 node ${PLUGIN_ROOT}/scripts/web-ctl.js session auth <session-name> --url <login-url> [--success-url <url>] [--success-selector <selector>] [--timeout <seconds>]
 ```
 
-This opens a **headed browser window** on the user's machine. Tell the user:
+**Display auto-detection**: If a local display is available, this opens a headed browser window. On remote servers (no display), it automatically falls back to VNC mode - launching Chrome in a virtual framebuffer with a noVNC web viewer.
 
-> A browser window has opened at <login-url>. Please complete the login process there. The window will close automatically when authentication is detected.
+Use `--vnc` to force VNC mode. Requires: `Xvfb`, `x11vnc`, `websockify`, `novnc`.
+
+**Headed mode** (local display):
+> A browser window has opened at <login-url>. Please complete the login process there.
+
+**VNC mode** (remote/headless):
+The command outputs a `vncUrl` - tell the user to open it in their browser to interact with the remote Chrome. If on a private network, they need to forward the port first:
+```
+ssh -L <port>:localhost:<port> <server>
+```
 
 ### 3. Parse Result
 
@@ -46,7 +55,9 @@ The command returns JSON:
 - `{ "ok": true, "session": "name", "url": "..." }` - Auth successful, session saved
 - `{ "ok": false, "error": "auth_timeout" }` - User did not complete auth in time
 - `{ "ok": false, "error": "auth_error", "message": "..." }` - Something went wrong
+- `{ "ok": false, "error": "no_display" }` - No display and VNC deps not installed
 - `{ "captchaDetected": true }` - CAPTCHA was detected during auth
+- `{ "vncUrl": "http://..." }` - VNC mode: URL for user to authenticate through
 
 ### 4. Handle Failures
 


### PR DESCRIPTION
## Summary

- Auto-detects when headed browser can't launch (no display/GPU)
- Falls back to Xvfb + x11vnc + noVNC - Chrome runs in virtual framebuffer, user authenticates via web-based VNC viewer
- `--vnc` flag to force VNC mode
- Prints SSH port forwarding hint when on private networks
- Requires: `Xvfb`, `x11vnc`, `websockify`, `novnc` (apt packages)

## Test plan

- [x] All 38 existing tests pass
- [x] VNC mode launches successfully with `DISPLAY=` unset
- [x] Auto-detection correctly falls back to VNC when no display
- [x] noVNC URL is printed with localhost (not private IP)
- [x] SSH tunnel hint shown for private networks
- [ ] End-to-end: authenticate via noVNC, verify cookies persist